### PR TITLE
Mac OS X 更名为 macOS

### DIFF
--- a/Best-App-Mac-Free.md
+++ b/Best-App-Mac-Free.md
@@ -13,9 +13,9 @@
 >注2：行末的 **#** 为相关 测评文章 或 同类横向对比文章 链接，请自行参阅。  
 >注3：本项目 **不接受** 任何形式的捐赠、资助或广告。
 
-## 1. 免费软件篇 (Mac OS)
+## 1. 免费软件篇 (macOS)
 
-`Mac OS`平台下有众多优秀的软件工具。
+`macOS`平台下有众多优秀的软件工具。
 下面先就付费软件做一个推荐列表，希望供大家购买付费App时参考。
 
 #### 1.1 效率工具类
@@ -25,8 +25,8 @@
 ★★★★★  | 添加中 ([评级说明](#%E5%85%B3%E4%BA%8E)) | 欢迎推荐 |  |
 ★★★★★  | InsomniaX ([评级说明](#%E5%85%B3%E4%BA%8E)) | 可以分别控制mac 在合上盖子和空闲超时后是否进入休眠状态的掉软件 | 0.00 |
 ★★★★★  | Bartender ([评级说明](#%E5%85%B3%E4%BA%8E)) | 隐藏菜单栏图标，还你干净的菜单栏 | 免费4周 |
-★★★★☆  | MacID ([MacID](https://macid.co)) | 用手指解锁 Mac，需要配合 iOS app | OSX 免费 |
-★★★★★  | Jietu ([Jietu](http://jietu.qq.com/)) | 腾讯良心出品的快捷标注、便捷分享的截屏工具 | OSX 免费 |
+★★★★☆  | MacID ([MacID](https://macid.co)) | 用手指解锁 Mac，需要配合 iOS app | macOS 免费 |
+★★★★★  | Jietu ([Jietu](http://jietu.qq.com/)) | 腾讯良心出品的快捷标注、便捷分享的截屏工具 | macOS 免费 |
 
 #### 1.2 开发类
 
@@ -44,7 +44,7 @@
 
 #### 2.1 不断更新中...
 
-## Mac OS App 优惠&促销信息媒体
+## macOS App 优惠&促销信息媒体
 
 * [AppShopper](http://appshopper.com/)
 * [MacUpdate](https://deals.macupdate.com/)

--- a/Best-App-iOS.md
+++ b/Best-App-iOS.md
@@ -78,7 +78,7 @@
 ★★★   | [欧路词典 Pro] | 翻译软件，支持离线词库，屏幕取词 | ￥18 | [#](http://www.eudic.net/eudic/mac_dictionary.aspx)
 ★★★   | [Mercury Browser Pro] | 浏览器 | $0.99 | [#](http://www.macworld.com/product/377687/mercury-web-browser-pro-the-most-advanced-brow.html)
 ★★★   | [Air Video] | 移动端播放电脑上的视频流，无需拷贝 | $2.99 | [#](http://www.tuaw.com/2013/11/05/how-a-pc-and-air-video-hd-turned-my-ipad-into-the-ultimate-enter/)
-★★★   | [MacID](https://itunes.apple.com/app/id948478740?mt=8&ls=1) | 手机解锁 Mac, iOS 和 OS X 间剪贴板，itunes 简单控制 | $3.99 | [#](https://itunes.apple.com/app/id948478740?mt=8&ls=1)
+★★★   | [MacID](https://itunes.apple.com/app/id948478740?mt=8&ls=1) | 手机解锁 Mac, iOS 和 macOS 间剪贴板，itunes 简单控制 | $3.99 | [#](https://itunes.apple.com/app/id948478740?mt=8&ls=1)
 
 ## 2. 付费 Cydia 插件篇
 


### PR DESCRIPTION
今天 WWDC 2016 宣布 Mac OS X 更名为 macOS，那么可以把项目里所有对 Mac 系统的称呼统一成 macOS 了。

个人觉得应当这样定义这两个名词：
Mac，指设备，比如 MacBook，Mac Pro 等设备
macOS，指系统，以后可以统一这些不规范的称呼：“Mac”、“苹果系统”、“Mac系统”、“Mac OS”、“OS X”