### PR TITLE
增加 steermouse 工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Best App
 <a href="#jitouch" name="jitouch">★</a>★★★☆ | [jitouch] | 触控板增强，画个字母B，打开浏览器 | $7.99 | [#](http://www.macworld.com/article/1151457/jitouch.html)
 <a href="#OmniFocus" name="OmniFocus">★</a>★★★☆ | [OmniFocus] | 著名 GTD，上手之后秒杀同类 | $79.99 | [#](http://www.asianefficiency.com/technology/omnifocus-mac-review/)
 <a href="#Keyboard-Maestro" name="Keyboard-Maestro">★</a>★★★☆ | [Keyboard Maestro] | 定制键盘快捷操作 | $36 | [#](http://mac.appstorm.net/how-to/productivity-how-to/how-to-become-a-mac-keyboard-maestro/)
-<a href="#SteerMouse" name="SteerMouse">★</a>★★★☆ | [SteerMouse] | 鼠标和键盘组合按键，让鼠标替代触摸板 | $19.99 | [#](https://download.cnet.com/SteerMouse/3000-18491_4-76439.html)
+<a href="#SteerMouse" name="SteerMouse">★</a>★★★☆ | [SteerMouse] | 鼠标和键盘组合按键，让鼠标替代触摸板手势 | $19.99 | [#](https://download.cnet.com/SteerMouse/3000-18491_4-76439.html)
 <a href="#PopClip" name="PopClip">★</a>★★★☆ | [PopClip] | 类 iOS 文字选中弹出 Menu 扩展 | $4.99 | [#](http://mac.appstorm.net/reviews/productivity-review/popclip-the-unexpectedly-awesome-productivity-tool/)
 <a href="#Clear" name="Clear">★</a>★★★☆ | [Clear] | 轻量级GTD工具、支持 iCloud 同步  | $9.99 | [#](https://www.macstories.net/reviews/clear-for-mac-review/)
 <a href="#BreakTime" name="BreakTime">★</a>★★★☆ | [BreakTime] | 健康管理和休息提醒，番茄工作法 | $4.99 | [#](http://www.macworld.com/article/1164136/break_time_reminds_you_to_take_five.html)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Best App
 <a href="#jitouch" name="jitouch">★</a>★★★☆ | [jitouch] | 触控板增强，画个字母B，打开浏览器 | $7.99 | [#](http://www.macworld.com/article/1151457/jitouch.html)
 <a href="#OmniFocus" name="OmniFocus">★</a>★★★☆ | [OmniFocus] | 著名 GTD，上手之后秒杀同类 | $79.99 | [#](http://www.asianefficiency.com/technology/omnifocus-mac-review/)
 <a href="#Keyboard-Maestro" name="Keyboard-Maestro">★</a>★★★☆ | [Keyboard Maestro] | 定制键盘快捷操作 | $36 | [#](http://mac.appstorm.net/how-to/productivity-how-to/how-to-become-a-mac-keyboard-maestro/)
-<a href="#Keyboard-Maestro" name="Keyboard-Maestro">★</a>★★★☆ | [SteerMouse] | 鼠标和键盘组合按键，让鼠标替代触摸板 | $19.99 | [#](http://plentycom.jp/en/steermouse/index.html)
+<a href="#SteerMouse" name="SteerMouse">★</a>★★★☆ | [SteerMouse] | 鼠标和键盘组合按键，让鼠标替代触摸板 | $19.99 | [#](https://download.cnet.com/SteerMouse/3000-18491_4-76439.html)
 <a href="#PopClip" name="PopClip">★</a>★★★☆ | [PopClip] | 类 iOS 文字选中弹出 Menu 扩展 | $4.99 | [#](http://mac.appstorm.net/reviews/productivity-review/popclip-the-unexpectedly-awesome-productivity-tool/)
 <a href="#Clear" name="Clear">★</a>★★★☆ | [Clear] | 轻量级GTD工具、支持 iCloud 同步  | $9.99 | [#](https://www.macstories.net/reviews/clear-for-mac-review/)
 <a href="#BreakTime" name="BreakTime">★</a>★★★☆ | [BreakTime] | 健康管理和休息提醒，番茄工作法 | $4.99 | [#](http://www.macworld.com/article/1164136/break_time_reminds_you_to_take_five.html)
@@ -248,6 +248,7 @@ Released under [MIT] LICENSE
 [CleanMyMac]: http://macpaw.com/cleanmymac
 [LockScreen]: https://itunes.apple.com/us/app/lock-screen-2/id445423011?mt=12
 [Moom]: http://manytricks.com/moom/
+[SteerMouse]: http://plentycom.jp/en/steermouse/index.html
 [OmmWriter]: http://www.ommwriter.com/
 [SaneDesk]: http://www.sanedeskapp.com/
 [Entropy]: http://www.eigenlogik.com/entropy/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Best App
 <a href="#jitouch" name="jitouch">★</a>★★★☆ | [jitouch] | 触控板增强，画个字母B，打开浏览器 | $7.99 | [#](http://www.macworld.com/article/1151457/jitouch.html)
 <a href="#OmniFocus" name="OmniFocus">★</a>★★★☆ | [OmniFocus] | 著名 GTD，上手之后秒杀同类 | $79.99 | [#](http://www.asianefficiency.com/technology/omnifocus-mac-review/)
 <a href="#Keyboard-Maestro" name="Keyboard-Maestro">★</a>★★★☆ | [Keyboard Maestro] | 定制键盘快捷操作 | $36 | [#](http://mac.appstorm.net/how-to/productivity-how-to/how-to-become-a-mac-keyboard-maestro/)
+<a href="#Keyboard-Maestro" name="Keyboard-Maestro">★</a>★★★☆ | [SteerMouse] | 鼠标和键盘组合按键，让鼠标替代触摸板 | $19.99 | [#](http://plentycom.jp/en/steermouse/index.html)
 <a href="#PopClip" name="PopClip">★</a>★★★☆ | [PopClip] | 类 iOS 文字选中弹出 Menu 扩展 | $4.99 | [#](http://mac.appstorm.net/reviews/productivity-review/popclip-the-unexpectedly-awesome-productivity-tool/)
 <a href="#Clear" name="Clear">★</a>★★★☆ | [Clear] | 轻量级GTD工具、支持 iCloud 同步  | $9.99 | [#](https://www.macstories.net/reviews/clear-for-mac-review/)
 <a href="#BreakTime" name="BreakTime">★</a>★★★☆ | [BreakTime] | 健康管理和休息提醒，番茄工作法 | $4.99 | [#](http://www.macworld.com/article/1164136/break_time_reminds_you_to_take_five.html)


### PR DESCRIPTION
steermouse 可以在鼠标侧键上设置键盘快捷键，使用鼠标的时候替代触摸板手势功能。
我常用的功能是，切换应用程序，切换多个MAC桌面，通过组合键加速滚动屏幕
![image](https://user-images.githubusercontent.com/12531101/79192022-84e55580-7e5a-11ea-87f2-a53a571b7592.png)
侧键切换应用程序

![image](https://user-images.githubusercontent.com/12531101/79192064-975f8f00-7e5a-11ea-89e7-cb7518b8ed01.png)
用 鼠标侧键+键盘 触发键盘快捷键，对应的键盘快捷键是上一个桌面和下一个桌面

![image](https://user-images.githubusercontent.com/12531101/79192308-0f2db980-7e5b-11ea-96d0-73bf9d0cb687.png)
按住cmd键，加速滚动滚轴